### PR TITLE
Tests in TypeScript, Mongo indices, few fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,8 @@ build/
 cli/build/
 
 # Cached files
-public/csv
-public/json
+/public/
+/public-test/
 
 # Misc
 run.bat

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,6 +299,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
     "@types/mongodb": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.1.tgz",
@@ -472,6 +478,12 @@
         }
       }
     },
+    "arg": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -581,6 +593,12 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1577,6 +1595,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -2349,6 +2373,22 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2466,6 +2506,27 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "ts-node": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
+      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "1.10.0",
@@ -2878,6 +2939,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
       "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "zip-stream": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "tslint ./src/**/*.ts",
     "start": "node .",
     "start-dev": "npm run lint && npm run build && npm start",
-    "test": "mocha",
+    "test": "mocha --require ts-node/register \"test/**/*.{js,ts,tsx}\"",
     "unic": "node build/cli/unic.js",
     "update": "git pull && npm install && npm run build"
   },
@@ -50,7 +50,9 @@
     "@types/sha.js": "^2.4.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
+    "ts-node": "8.4.1",
     "mocha": "^6.2.0",
+    "@types/mocha": "5.2.7",
     "should": "^13.2.3",
     "tslint": "^5.18.0"
   }

--- a/src/BlacklistManager.ts
+++ b/src/BlacklistManager.ts
@@ -5,13 +5,18 @@ export interface BlacklistEntry {
 }
 
 export class BlacklistManager {
-    private collection: Collection<BlacklistEntry>;
-
-    constructor(db: Db) {
-        this.collection = db.collection("blacklist");
-        this.collection.createIndexes([
+    public static async create(db: Db): Promise<BlacklistManager> {
+        const collection = db.collection("blacklist");
+        await collection.createIndexes([
             { key: { uploaderID: 1 }, unique: true }
         ]);
+        return new BlacklistManager(collection);
+    }
+
+    private collection: Collection<BlacklistEntry>;
+
+    private constructor(collection: Collection<BlacklistEntry>) {
+        this.collection = collection;
     }
 
     /** Add an uploader to the blacklist, preventing their data from being processed. */

--- a/src/BlacklistManager.ts
+++ b/src/BlacklistManager.ts
@@ -1,20 +1,26 @@
-import { Collection } from "mongodb";
+import { Collection, Db } from "mongodb";
+
+export interface BlacklistEntry {
+    uploaderID: string
+}
 
 export class BlacklistManager {
-    private blacklist: Collection;
+    private collection: Collection<BlacklistEntry>;
 
-    constructor(blacklist: Collection) {
-        this.blacklist = blacklist;
+    constructor(db: Db) {
+        this.collection = db.collection("blacklist");
+        this.collection.createIndexes([
+            { key: { uploaderID: 1 }, unique: true }
+        ])
     }
 
     /** Add an uploader to the blacklist, preventing their data from being processed. */
     public async add(uploaderID: string): Promise<void> {
-        await this.blacklist.insertOne({ uploaderID });
+        await this.collection.insertOne({ uploaderID });
     }
 
     /** Check if the blacklist has an uploader. */
     public async has(uploaderID: string): Promise<boolean> {
-        const exists = await this.blacklist.findOne({ uploaderID });
-        return exists ? true : false;
+        return await this.collection.findOne({ uploaderID }) != null;
     }
 }

--- a/src/BlacklistManager.ts
+++ b/src/BlacklistManager.ts
@@ -1,7 +1,7 @@
 import { Collection, Db } from "mongodb";
 
 export interface BlacklistEntry {
-    uploaderID: string
+    uploaderID: string;
 }
 
 export class BlacklistManager {
@@ -11,7 +11,7 @@ export class BlacklistManager {
         this.collection = db.collection("blacklist");
         this.collection.createIndexes([
             { key: { uploaderID: 1 }, unique: true }
-        ])
+        ]);
     }
 
     /** Add an uploader to the blacklist, preventing their data from being processed. */

--- a/src/BlacklistManager.ts
+++ b/src/BlacklistManager.ts
@@ -1,4 +1,4 @@
-import { Collection, Db } from "mongodb";
+import { Collection, Db, MongoError } from "mongodb";
 
 export interface BlacklistEntry {
     uploaderID: string;
@@ -21,7 +21,11 @@ export class BlacklistManager {
 
     /** Add an uploader to the blacklist, preventing their data from being processed. */
     public async add(uploaderID: string): Promise<void> {
-        await this.collection.insertOne({ uploaderID });
+        try {
+            await this.collection.insertOne({ uploaderID });
+        } catch (e) {
+            if ((e as MongoError).code !== 11000) throw e;
+        }
     }
 
     /** Check if the blacklist has an uploader. */

--- a/src/RemoteDataManager.ts
+++ b/src/RemoteDataManager.ts
@@ -45,7 +45,7 @@ export class RemoteDataManager {
         this.remoteFileDirectory = options.remoteFileDirectory ? options.remoteFileDirectory : "../public";
 
         for (const ext of this.exts) {
-            const extPath = path.join(__dirname, this.remoteFileDirectory, ext)
+            const extPath = path.join(__dirname, this.remoteFileDirectory, ext);
             if (!fs.existsSync(extPath)) {
                 fs.mkdirSync(extPath, { recursive: true });
             }
@@ -111,7 +111,7 @@ export class RemoteDataManager {
         const filePath = path.join(__dirname, this.remoteFileDirectory, ext, fileName);
 
         if (!await exists(filePath)) {
-            let remoteData = await request(urlDictionary[fileName]);
+            const remoteData = await request(urlDictionary[fileName]);
             await writeFile(filePath, remoteData);
 
             remoteFileMap.set(fileName, remoteData);

--- a/src/RemoteDataManager.ts
+++ b/src/RemoteDataManager.ts
@@ -18,21 +18,21 @@ const urlDictionary = {
     "data.json": "https://www.garlandtools.org/db/doc/core/en/3/data.json",
     "dc.json": "https://xivapi.com/servers/dc",
     "search_de.json": "https://xivapi.com/search?string=" +
-                      "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
-                      "&columns=ID,IconID,ItemSearchCategory.Name_de,LevelItem,Name_de",
+        "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
+        "&columns=ID,IconID,ItemSearchCategory.Name_de,LevelItem,Name_de",
     "search_en.json": "https://xivapi.com/search?string=" +
-                      "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
-                      "&columns=ID,IconID,ItemSearchCategory.Name_en,LevelItem,Name_en",
+        "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
+        "&columns=ID,IconID,ItemSearchCategory.Name_en,LevelItem,Name_en",
     "search_fr.json": "https://xivapi.com/search?string=" +
-                      "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
-                      "&columns=ID,IconID,ItemSearchCategory.Name_fr,LevelItem,Name_fr",
+        "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
+        "&columns=ID,IconID,ItemSearchCategory.Name_fr,LevelItem,Name_fr",
     "search_jp.json": "https://xivapi.com/search?string=" +
-                      "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
-                      "&columns=ID,IconID,ItemSearchCategory.Name_jp,LevelItem,Name_jp",
+        "&string_algo=wildcard_plus&indexes=item&filters=ItemSearchCategory.ID%3E8" +
+        "&columns=ID,IconID,ItemSearchCategory.Name_jp,LevelItem,Name_jp",
 };
 
-const csvMap = new Map();
-const remoteFileMap = new Map();
+const csvMap = new Map<string, string[][]>();
+const remoteFileMap = new Map<string, Buffer>();
 
 export class RemoteDataManager {
     private exts: string[];
@@ -45,14 +45,15 @@ export class RemoteDataManager {
         this.remoteFileDirectory = options.remoteFileDirectory ? options.remoteFileDirectory : "../public";
 
         for (const ext of this.exts) {
-            if (!fs.existsSync(path.join(__dirname, `${this.remoteFileDirectory}/${ext}`))) {
-                fs.mkdirSync(path.join(__dirname, `${this.remoteFileDirectory}/${ext}`));
+            const extPath = path.join(__dirname, this.remoteFileDirectory, ext)
+            if (!fs.existsSync(extPath)) {
+                fs.mkdirSync(extPath, { recursive: true });
             }
         }
     }
 
     /** Parse a CSV, retrieving it if it does not already exist. */
-    public async parseCSV(fileName: string): Promise<any> {
+    public async parseCSV(fileName: string): Promise<string[][]> {
         if (csvMap.get(fileName)) {
             return csvMap.get(fileName);
         }
@@ -63,13 +64,13 @@ export class RemoteDataManager {
             delimiter: ","
         });
 
-        const data: Promise<any[]> = new Promise((resolve) => {
+        const data: Promise<string[][]> = new Promise((resolve) => {
             const output = [];
 
             parser.write(table);
 
             parser.on("readable", () => {
-                let record: any = parser.read();
+                let record: string[] = parser.read();
                 while (record) {
                     output.push(record);
                     record = parser.read();
@@ -106,24 +107,19 @@ export class RemoteDataManager {
 
     /** Get local copies of certain remote files, should they not exist locally. */
     public async fetchFile(fileName: string): Promise<Buffer> {
-        const ext = fileName.substr(fileName.indexOf(".") + 1);
-        const file = await exists(path.join(__dirname, this.remoteFileDirectory, ext, fileName));
+        const ext = fileName.substr(fileName.lastIndexOf(".") + 1);
+        const filePath = path.join(__dirname, this.remoteFileDirectory, ext, fileName);
 
-        if (!file) {
-            let remoteData: any;
-
-            remoteData = await request(urlDictionary[fileName]);
-            await writeFile(path.join(__dirname, this.remoteFileDirectory, ext, fileName), remoteData);
+        if (!await exists(filePath)) {
+            let remoteData = await request(urlDictionary[fileName]);
+            await writeFile(filePath, remoteData);
 
             remoteFileMap.set(fileName, remoteData);
 
             return remoteData;
         } else {
             if (!remoteFileMap.get(fileName)) {
-                remoteFileMap.set(
-                    fileName,
-                    await readFile(path.join(__dirname, this.remoteFileDirectory, ext, fileName))
-                );
+                remoteFileMap.set(fileName, await readFile(filePath));
             }
 
             return remoteFileMap.get(fileName);

--- a/src/RemoteDataManager.ts
+++ b/src/RemoteDataManager.ts
@@ -61,6 +61,7 @@ export class RemoteDataManager {
         const table = await this.fetchFile(fileName);
 
         const parser = csvParser({
+            bom: true,
             delimiter: ","
         });
 

--- a/src/TrustedSourceManager.ts
+++ b/src/TrustedSourceManager.ts
@@ -1,4 +1,4 @@
-import { Collection, Db } from "mongodb";
+import { Collection, Db, MongoError } from "mongodb";
 import { sha512 } from "sha.js";
 import { TrustedSource } from "./models/TrustedSource";
 
@@ -18,11 +18,15 @@ export class TrustedSourceManager {
     }
 
     public async addToTrusted(apiKey: string, sourceName: string): Promise<void> {
-        await this.collection.insertOne({
-            apiKey: this.apiKeyHash(apiKey),
-            sourceName,
-            uploadCount: 0,
-        });
+        try {
+            await this.collection.insertOne({
+                apiKey: this.apiKeyHash(apiKey),
+                sourceName,
+                uploadCount: 0,
+            });
+        } catch (e) {
+            if ((e as MongoError).code !== 11000) throw e;
+        }
     }
 
     public async get(apiKey: string): Promise<TrustedSource> {

--- a/src/TrustedSourceManager.ts
+++ b/src/TrustedSourceManager.ts
@@ -1,0 +1,37 @@
+import { Db, Collection } from "mongodb";
+import { sha512 } from "sha.js";
+import { TrustedSource } from "./models/TrustedSource";
+
+export class TrustedSourceManager {
+    private collection: Collection<TrustedSource>
+
+    constructor(db: Db) {
+        this.collection = db.collection("trustedSources")
+        this.collection.createIndexes([
+            { key: { apiKey: 1 }, unique: true }
+        ])
+    }
+
+    private apiKeyHash(apiKey: string): string {
+        return new sha512().update(apiKey).digest("hex")
+    }
+
+    public async addToTrusted(apiKey: string, sourceName: string): Promise<void> {
+        await this.collection.insertOne({
+            apiKey: this.apiKeyHash(apiKey),
+            sourceName,
+            uploadCount: 0,
+        })
+    }
+
+    public async get(apiKey: string): Promise<TrustedSource> {
+        return await this.collection.findOne({ apiKey: this.apiKeyHash(apiKey) })
+    }
+
+    public async increaseUploadCount(apiKey: string, increase: number = 1) {
+        return await this.collection.updateOne(
+            { apiKey: this.apiKeyHash(apiKey) },
+            { $inc: { uploadCount: increase } }
+        )
+    }
+}

--- a/src/TrustedSourceManager.ts
+++ b/src/TrustedSourceManager.ts
@@ -3,13 +3,18 @@ import { sha512 } from "sha.js";
 import { TrustedSource } from "./models/TrustedSource";
 
 export class TrustedSourceManager {
-    private collection: Collection<TrustedSource>;
-
-    constructor(db: Db) {
-        this.collection = db.collection("trustedSources");
-        this.collection.createIndexes([
+    public static async create(db: Db): Promise<TrustedSourceManager> {
+        const collection = db.collection("trustedSources");
+        await collection.createIndexes([
             { key: { apiKey: 1 }, unique: true }
         ]);
+        return new TrustedSourceManager(collection);
+    }
+
+    private collection: Collection<TrustedSource>;
+
+    private constructor(collection: Collection<TrustedSource>) {
+        this.collection = collection;
     }
 
     public async addToTrusted(apiKey: string, sourceName: string): Promise<void> {

--- a/src/TrustedSourceManager.ts
+++ b/src/TrustedSourceManager.ts
@@ -1,19 +1,15 @@
-import { Db, Collection } from "mongodb";
+import { Collection, Db } from "mongodb";
 import { sha512 } from "sha.js";
 import { TrustedSource } from "./models/TrustedSource";
 
 export class TrustedSourceManager {
-    private collection: Collection<TrustedSource>
+    private collection: Collection<TrustedSource>;
 
     constructor(db: Db) {
-        this.collection = db.collection("trustedSources")
+        this.collection = db.collection("trustedSources");
         this.collection.createIndexes([
             { key: { apiKey: 1 }, unique: true }
-        ])
-    }
-
-    private apiKeyHash(apiKey: string): string {
-        return new sha512().update(apiKey).digest("hex")
+        ]);
     }
 
     public async addToTrusted(apiKey: string, sourceName: string): Promise<void> {
@@ -21,17 +17,21 @@ export class TrustedSourceManager {
             apiKey: this.apiKeyHash(apiKey),
             sourceName,
             uploadCount: 0,
-        })
+        });
     }
 
     public async get(apiKey: string): Promise<TrustedSource> {
-        return await this.collection.findOne({ apiKey: this.apiKeyHash(apiKey) })
+        return await this.collection.findOne({ apiKey: this.apiKeyHash(apiKey) });
     }
 
     public async increaseUploadCount(apiKey: string, increase: number = 1) {
         return await this.collection.updateOne(
             { apiKey: this.apiKeyHash(apiKey) },
             { $inc: { uploadCount: increase } }
-        )
+        );
+    }
+
+    private apiKeyHash(apiKey: string): string {
+        return new sha512().update(apiKey).digest("hex");
     }
 }

--- a/src/universalis.ts
+++ b/src/universalis.ts
@@ -76,13 +76,12 @@ const init = (async () => {
     // DB Data Managers
     const universalisDB = (await db).db("universalis");
 
-    const blacklist = universalisDB.collection("blacklist");
     const contentCollection = universalisDB.collection("content");
     extendedHistory = universalisDB.collection("extendedHistory");
     const extraData = universalisDB.collection("extraData");
     recentData = universalisDB.collection("recentData");
 
-    blacklistManager = new BlacklistManager(blacklist);
+    blacklistManager = new BlacklistManager(universalisDB);
     contentIDCollection = new ContentIDCollection(contentCollection);
     extraDataManager = new ExtraDataManager(extraData, recentData);
     historyTracker = new HistoryTracker(recentData, extendedHistory);

--- a/src/universalis.ts
+++ b/src/universalis.ts
@@ -91,7 +91,7 @@ const init = (async () => {
     // World-ID conversions
     const worldList = await remoteDataManager.parseCSV("World.csv");
 	for (let worldEntry of worldList) {
-        if (worldEntry[0] == 25) continue;
+        if (worldEntry[0] == "25") continue;
 	    worldMap.set(worldEntry[1], parseInt(worldEntry[0]));
 	}
 
@@ -308,7 +308,7 @@ router.get("/api/extra/stats/upload-history", async (ctx) => { // Upload rate
     const data: DailyUploadStatistics = await extraDataManager.getDailyUploads(daysToReturn);
 
     if (!data) {
-        ctx.body =  {
+        ctx.body = {
             uploadCountByDay: []
         } as DailyUploadStatistics;
         return;
@@ -326,7 +326,7 @@ router.get("/api/extra/stats/recently-updated", async (ctx) => { // Recently upd
     const data: RecentlyUpdated = await extraDataManager.getRecentlyUpdatedItems(entriesToReturn);
 
     if (!data) {
-        ctx.body =  {
+        ctx.body = {
             items: []
         } as RecentlyUpdated;
         return;
@@ -344,7 +344,7 @@ router.get("/api/extra/stats/least-recently-updated", async (ctx) => { // Recent
     const data: WorldItemPairList = await extraDataManager.getLeastRecentlyUpdatedItems(entriesToReturn);
 
     if (!data) {
-        ctx.body =  {
+        ctx.body = {
             items: []
         } as WorldItemPairList;
         return;
@@ -364,20 +364,15 @@ router.post("/upload/:apiKey", async (ctx) => { // Kinda like a main loop
     const promises: Array<Promise<any>> = []; // Sort of like a thread list.
 
     // Accept identity via API key.
-    const dbo = (await db).db("universalis");
+    const trustedSources = (await db).db("universalis").collection("trustedSources");
     const apiKey = sha("sha512").update(ctx.params.apiKey).digest("hex");
-    const trustedSource: TrustedSource = await dbo.collection("trustedSources").findOne({ apiKey });
+    const trustedSource: TrustedSource = await trustedSources.findOne({ apiKey });
     if (!trustedSource) return ctx.throw(401);
 
     const sourceName = trustedSource.sourceName;
 
-    if (trustedSource.uploadCount) promises.push(dbo.collection("trustedSources").updateOne({ apiKey }, {
+    promises.push(trustedSources.updateOne({ apiKey }, {
         $inc: {
-            uploadCount: 1
-        }
-    }));
-    else promises.push(dbo.collection("trustedSources").updateOne({ apiKey }, {
-        $set: {
             uploadCount: 1
         }
     }));
@@ -392,7 +387,7 @@ router.post("/upload/:apiKey", async (ctx) => { // Kinda like a main loop
         CharacterContentIDUpload &
         MarketBoardListingsUpload &
         MarketBoardSaleHistoryUpload
-    = ctx.request.body;
+        = ctx.request.body;
 
     uploadData.uploaderID = sha("sha256").update(uploadData.uploaderID + "").digest("hex");
 

--- a/src/universalis.ts
+++ b/src/universalis.ts
@@ -81,14 +81,14 @@ const init = (async () => {
     const extraData = universalisDB.collection("extraData");
     recentData = universalisDB.collection("recentData");
 
-    blacklistManager = new BlacklistManager(universalisDB);
+    blacklistManager = await BlacklistManager.create(universalisDB);
     contentIDCollection = new ContentIDCollection(contentCollection);
     extraDataManager = new ExtraDataManager(extraData, recentData);
     historyTracker = new HistoryTracker(recentData, extendedHistory);
     priceTracker = new PriceTracker(recentData);
     remoteDataManager = new RemoteDataManager({ logger });
     remoteDataManager.fetchAll();
-    trustedSourceManager = new TrustedSourceManager(universalisDB);
+    trustedSourceManager = await TrustedSourceManager.create(universalisDB);
 
     // World-ID conversions
     const worldList = await remoteDataManager.parseCSV("World.csv");

--- a/test/BlacklistManagerTest.ts
+++ b/test/BlacklistManagerTest.ts
@@ -1,0 +1,25 @@
+import should from "should";
+import { BlacklistManager } from "../src/BlacklistManager";
+import { MongoFixture } from "./MongoFixture";
+
+const dummyUploaderID: string = "dummyUploaderID";
+
+describe("BlacklistManager", () => {
+    const mongo = new MongoFixture();
+
+    var manager: BlacklistManager;
+
+    before(async () => {
+        await mongo.before();
+        manager = await BlacklistManager.create(mongo.db);
+    });
+
+    after(async () => await mongo.after());
+
+    it("should allow blacklisting of uploaders", async () => {
+        should.equal(await manager.has(dummyUploaderID), false);
+        await manager.add(dummyUploaderID);
+        await manager.add(dummyUploaderID);
+        should.equal(await manager.has(dummyUploaderID), true);
+    });
+});

--- a/test/MongoFixture.ts
+++ b/test/MongoFixture.ts
@@ -1,0 +1,26 @@
+import { Db, MongoClient } from "mongodb";
+
+export class MongoFixture {
+    private mongoUri: string;
+
+    private client: MongoClient;
+    private _db: Db;
+
+    public constructor(mongoUri: string = "mongodb://localhost") {
+        this.mongoUri = mongoUri;
+    }
+
+    public async before(): Promise<void> {
+        this.client = await MongoClient.connect(this.mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+        this._db = this.client.db("universalis-test");
+        await this._db.dropDatabase();
+    }
+
+    public async after(): Promise<void> {
+        await this.client.close();
+    }
+
+    public get db(): Db {
+        return this._db;
+    }
+}

--- a/test/RemoteDataManagerTest.ts
+++ b/test/RemoteDataManagerTest.ts
@@ -1,0 +1,18 @@
+import { RemoteDataManager } from "../src/RemoteDataManager";
+import should from "should";
+import winston = require("winston");
+
+describe("RemoteDataManager", () => {
+    const logger = winston.createLogger();
+    const manager: RemoteDataManager = new RemoteDataManager({ logger, remoteFileDirectory: "../public-test" });
+
+    it("should retrieve CSV files properly", async () => {
+        const json = JSON.parse((await manager.fetchFile("dc.json")).toString());
+        should.equal(json.Light[4], "Zodiark");
+    })
+
+    it("should parse CSV files properly", async () => {
+        const csv = await manager.parseCSV("World.csv");
+        should.deepEqual(csv[0], ["key", "0", "1", "2", "3"]);
+    })
+});

--- a/test/TrustedSourceManagerTest.ts
+++ b/test/TrustedSourceManagerTest.ts
@@ -1,0 +1,40 @@
+import { MongoClient } from "mongodb";
+import should from "should";
+import { TrustedSourceManager } from "../src/TrustedSourceManager";
+
+const dummyKey = "dummyKey";
+
+describe("TrustedSourceManager", () => {
+    var client: MongoClient;
+    var manager: TrustedSourceManager;
+
+    before(async () => {
+        client = await MongoClient.connect("mongodb://localhost", { useNewUrlParser: true, useUnifiedTopology: true });
+        const db = client.db("universalis-test");
+        await db.dropDatabase();
+        manager = await TrustedSourceManager.create(db);
+    });
+
+    after(async () => {
+        await client.close();
+    });
+
+    it("should report unkown keys as not trusted", async () => {
+        should.not.exist(await manager.get(dummyKey));
+    });
+
+    it("should store new api keys properly", async () => {
+        await manager.addToTrusted(dummyKey, "tests");
+    });
+
+    it("should recognize stored keys", async () => {
+        should.exist(await manager.get(dummyKey));
+    });
+
+    it("should store update counts", async () => {
+        await manager.increaseUploadCount(dummyKey, 99);
+        await manager.increaseUploadCount(dummyKey);
+        const source = await manager.get(dummyKey);
+        should.equal(source.uploadCount, 100);
+    });
+});

--- a/test/TrustedSourceManagerTest.ts
+++ b/test/TrustedSourceManagerTest.ts
@@ -1,29 +1,28 @@
 import { MongoClient } from "mongodb";
 import should from "should";
 import { TrustedSourceManager } from "../src/TrustedSourceManager";
+import { MongoFixture } from "./MongoFixture";
 
-const dummyKey = "dummyKey";
+const dummyKey: string = "dummyKey";
 
 describe("TrustedSourceManager", () => {
-    var client: MongoClient;
+    const mongo = new MongoFixture();
+
     var manager: TrustedSourceManager;
 
     before(async () => {
-        client = await MongoClient.connect("mongodb://localhost", { useNewUrlParser: true, useUnifiedTopology: true });
-        const db = client.db("universalis-test");
-        await db.dropDatabase();
-        manager = await TrustedSourceManager.create(db);
+        await mongo.before();
+        manager = await TrustedSourceManager.create(mongo.db);
     });
 
-    after(async () => {
-        await client.close();
-    });
+    after(async () => await mongo.after());
 
     it("should report unkown keys as not trusted", async () => {
         should.not.exist(await manager.get(dummyKey));
     });
 
-    it("should store new api keys properly", async () => {
+    it("should store new api keys properly, even when added multiple times", async () => {
+        await manager.addToTrusted(dummyKey, "tests");
         await manager.addToTrusted(dummyKey, "tests");
     });
 

--- a/tslint.json
+++ b/tslint.json
@@ -5,19 +5,26 @@
     ],
     "jsRules": {},
     "rules": {
-        "curly": [ false ],
-        "interface-name": [ false ],
-        "no-angle-bracket-type-assertion": [ false ],
+        "curly": false,
+        "interface-name": false,
+        "no-angle-bracket-type-assertion": false,
         "no-console": {
             "severity": "warning"
         },
-        "no-string-literal": [ false ],
-        "no-var-keyword": [ false ],
+        "no-string-literal": false,
+        "no-var-keyword": false,
         "prefer-const": {
             "severity": "warning"
         },
-        "radix": [ false ],
-        "trailing-comma": [ false ]
+        "radix": false,
+        "trailing-comma": false,
+        "variable-name": {
+            "options": [
+                "ban-keywords",
+                "check-format",
+                "allow-leading-underscore"
+            ]
+        }
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
- added `ts-node` dependency to support writing tests in TypeScript
- modified `BlacklistManager`, created `TrustedSourceManager` as examples of async Mongo-based stores with proper index initialization
- added type information to `RemoteDataManager`, fixed BOM handling
- allowed variable names starting with `_` in `tslint` config