### PR TITLE
Fix dupes in World.csv causing wrong ID mapping

### DIFF
--- a/src/universalis.ts
+++ b/src/universalis.ts
@@ -83,7 +83,7 @@ const init = (async () => {
     // World-ID conversions
     const worldList = await remoteDataManager.parseCSV("World.csv");
 	for (const worldEntry of worldList) {
-        if (!parseInt(worldEntry[0]) || worldEntry[0] === "25") continue;
+        if (!parseInt(worldEntry[0]) || worldEntry[0] === "25" || worldEntry[4] === "False") continue;
         worldMap.set(worldEntry[1], parseInt(worldEntry[0]));
         worldIDMap.set(parseInt(worldEntry[0]), worldEntry[1]);
 	}


### PR DESCRIPTION
Hello,

This fix ignores the worlds that aren't flagged as public in the World.csv file.

This solves an issue causing the worldMap entries to be overwritten with a wrong ID for the 3 worlds Chocobo, Moogle, and Namazu.

Example:
[https://universalis.app/api/Moogle/27750](https://universalis.app/api/Moogle/27750) at this link, you can see that Moogle is resolved as worldID 166, where it should've been resolved as worldID 71.
[https://universalis.app/api/71/27750](https://universalis.app/api/71/27750) works properly and returns the actual results from Moogle.